### PR TITLE
add background-running gadgets and lifecycle tools

### DIFF
--- a/pkg/tools/lifecycle.go
+++ b/pkg/tools/lifecycle.go
@@ -1,0 +1,75 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+func (r *GadgetToolRegistry) newStopTool() server.ServerTool {
+	opts := []mcp.ToolOption{
+		mcp.WithDescription("Stops a gadget with an ID"),
+		mcp.WithString("id",
+			mcp.Description("ID of the running gadget"),
+		),
+		mcp.WithReadOnlyHintAnnotation(true),
+	}
+	tool := mcp.NewTool(
+		"stop-gadget",
+		opts...,
+	)
+	return server.ServerTool{
+		Tool:    tool,
+		Handler: r.stopHandler(),
+	}
+}
+
+func (r *GadgetToolRegistry) stopHandler() server.ToolHandlerFunc {
+	return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		id := request.GetString("id", "")
+		if id == "" {
+			return nil, fmt.Errorf("an id is required")
+		}
+
+		err := r.gadgetMgr.Stop(id)
+		if err != nil {
+			return nil, fmt.Errorf("failed to stop gadget with id %q: %w", id, err)
+		}
+		return mcp.NewToolResultText(fmt.Sprintf("Gadget with ID %q has been stopped", id)), nil
+	}
+}
+
+func (r *GadgetToolRegistry) newGetResultsTool() server.ServerTool {
+	opts := []mcp.ToolOption{
+		mcp.WithDescription("Returns the collected events from a gadget instance with a specific ID. Please review the data and provide a concise summary to the user."),
+		mcp.WithString("id",
+			mcp.Description("ID of the running gadget instance"),
+		),
+		mcp.WithReadOnlyHintAnnotation(true),
+	}
+	tool := mcp.NewTool(
+		"get-results",
+		opts...,
+	)
+	return server.ServerTool{
+		Tool:    tool,
+		Handler: r.getResultsHandler(),
+	}
+}
+
+func (r *GadgetToolRegistry) getResultsHandler() server.ToolHandlerFunc {
+	return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		id := request.GetString("id", "")
+		if id == "" {
+			return nil, fmt.Errorf("an id is required")
+		}
+
+		resp, err := r.gadgetMgr.Results(id)
+		if err != nil {
+			return nil, fmt.Errorf("attaching to gadget %s: %w", id, err)
+		}
+		return mcp.NewToolResultText(truncateResults(resp)), nil
+	}
+}

--- a/pkg/tools/templates/toolDescription.tmpl
+++ b/pkg/tools/templates/toolDescription.tmpl
@@ -1,7 +1,18 @@
-The {{ .Name }} tool is designed to {{ .Description }} in {{ .Environment }} environments using a gadget. It uses a map of key-value pairs called params to configure its behavior but does not require any specific parameters to function.
+The {{ .Name }} tool is designed to {{ .Description }} in {{ .Environment }} environments using a gadget.
+It uses a map of key-value pairs called params to configure its behavior but does not require any specific parameters to function.
+
+The tool can either be run for a specified amount of time by setting the timeout parameter (returning the results afterwards)
+or started to be run in the background (set `background` to `true` in that case). When running in the background, the
+tool will return a unique identifier (ID) of the newly created gadget instance. This ID can be used when calling
+`get-results` and `stop-gadget` to control the corresponding gadget instance. Running a gadget in the background allows
+capturing events while running other tasks (like triggering events using other tools) or conversing with the user.
+
+Make sure to always stop gadgets using `stop-gadget` after you are done with them as they will otherwise waste resources
+on the host. Also make sure to get the results before calling `stop-gadget`, as the results won't be available anymore
+after calling `stop-gadget`.
 
 ## Usage
-Always ask users question to apply limit the data volume. Here are some examples of questions you can ask:
+Always ask users questions so that the results can be filtered to a minimum. Here are some examples of questions you can ask:
 - Do you want to filter for specific namespace/pod/node?
 - Do you want to filter for specific fields?
 
@@ -13,4 +24,4 @@ Fields can be filtered using the `operator.filter.filter` param. Format: FIELD (
 {{ end }}
 ## Output
 
-The tool produces a JSON object as output; review the data and provide a concise summary to the user.
+The tool produces a JSON object as output when not running in the background; review the data and provide a concise summary to the user.

--- a/pkg/tools/wait.go
+++ b/pkg/tools/wait.go
@@ -1,0 +1,43 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+func newWaitTool() server.ServerTool {
+	opts := []mcp.ToolOption{
+		mcp.WithDescription("Wait for a given amount of time"),
+		mcp.WithNumber("waitTime",
+			mcp.Description("Number of seconds to wait"),
+		),
+		mcp.WithReadOnlyHintAnnotation(true),
+	}
+	tool := mcp.NewTool(
+		"wait",
+		opts...,
+	)
+	return server.ServerTool{
+		Tool:    tool,
+		Handler: waitHandler(),
+	}
+}
+
+func waitHandler() server.ToolHandlerFunc {
+	return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		waitTime := request.GetInt("waitTime", 1)
+		time.Sleep(time.Duration(waitTime) * time.Second)
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				mcp.TextContent{
+					Type: "text",
+					Text: fmt.Sprintf("%d seconds have passed", waitTime),
+				},
+			},
+		}, nil
+	}
+}


### PR DESCRIPTION
This adds support for running gadgets in the background. It also truncates results, if necessary.