### PR TITLE
feat: add -namespace flag for custom Inspektor Gadget namespace

### DIFF
--- a/cmd/ig-mcp-server/main.go
+++ b/cmd/ig-mcp-server/main.go
@@ -44,6 +44,7 @@ var (
 	// Inspektor Gadget configuration
 	environment                   = flag.String("environment", "kubernetes", "environment to use (currently only 'kubernetes' or 'linux' is supported)")
 	linuxRemoteAddress            = flag.String("linux-remote-address", "unix:///var/run/ig/ig.socket", "Comma-separated list of remote address (gRPC) to connect (unix:///var/run/ig/ig.socket)")
+	gadgetNamespace               = flag.String("namespace", "", "namespace where Inspektor Gadget is deployed (default: gadget)")
 	gadgetImages                  = flag.String("gadget-images", "", "comma-separated list of gadget images to use (e.g. 'trace_dns:latest,trace_open:latest')")
 	gadgetDiscoverer              = flag.String("gadget-discoverer", "artifacthub", "gadget discoverer to use (artifacthub)")
 	artifactHubDiscovererOfficial = flag.Bool("artifacthub-official", true, "use only official gadgets from Artifact Hub")
@@ -94,7 +95,7 @@ func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
-	mgr, err := gadgetmanager.NewGadgetManager(*environment, *linuxRemoteAddress, k8sConfig)
+	mgr, err := gadgetmanager.NewGadgetManager(*environment, *linuxRemoteAddress, k8sConfig, *gadgetNamespace)
 	if err != nil {
 		logFatal("failed to create gadget manager", "error", err)
 	}

--- a/cmd/ig-mcp-server/main.go
+++ b/cmd/ig-mcp-server/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/inspektor-gadget/ig-mcp-server/pkg/gadgetmanager"
 	"github.com/inspektor-gadget/ig-mcp-server/pkg/server"
 	"github.com/inspektor-gadget/ig-mcp-server/pkg/tools"
+	lifecycledeploy "github.com/inspektor-gadget/ig-mcp-server/pkg/tools/lifecycle/deploy"
 )
 
 // This variable is used by the "version" command and is set during build
@@ -44,6 +45,7 @@ var (
 	// Inspektor Gadget configuration
 	environment                   = flag.String("environment", "kubernetes", "environment to use (currently only 'kubernetes' or 'linux' is supported)")
 	linuxRemoteAddress            = flag.String("linux-remote-address", "unix:///var/run/ig/ig.socket", "Comma-separated list of remote address (gRPC) to connect (unix:///var/run/ig/ig.socket)")
+	gadgetNamespace               = flag.String("namespace", "", "namespace where Inspektor Gadget is deployed (auto-detected, falls back to 'gadget')")
 	gadgetImages                  = flag.String("gadget-images", "", "comma-separated list of gadget images to use (e.g. 'trace_dns:latest,trace_open:latest')")
 	gadgetDiscoverer              = flag.String("gadget-discoverer", "artifacthub", "gadget discoverer to use (artifacthub)")
 	artifactHubDiscovererOfficial = flag.Bool("artifacthub-official", true, "use only official gadgets from Artifact Hub")
@@ -94,7 +96,18 @@ func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
-	mgr, err := gadgetmanager.NewGadgetManager(*environment, *linuxRemoteAddress, k8sConfig)
+	namespace := *gadgetNamespace
+	if *environment == "kubernetes" && namespace == "" {
+		deployed, discovered, err := lifecycledeploy.IsInspektorGadgetDeployed(ctx)
+		if err != nil {
+			log.Warn("Failed to auto-discover gadget namespace, falling back to default", "error", err)
+		} else if deployed {
+			log.Info("Auto-discovered gadget namespace", "namespace", discovered)
+			namespace = discovered
+		}
+	}
+
+	mgr, err := gadgetmanager.NewGadgetManager(*environment, *linuxRemoteAddress, k8sConfig, namespace)
 	if err != nil {
 		logFatal("failed to create gadget manager", "error", err)
 	}

--- a/pkg/gadgetmanager/gadgetmanager.go
+++ b/pkg/gadgetmanager/gadgetmanager.go
@@ -67,14 +67,15 @@ type GadgetInstance struct {
 }
 
 type gadgetManager struct {
-	k8sConfig   *genericclioptions.ConfigFlags
-	formatterMu sync.Mutex
-	env         string
-	remoteAddr  string
+	k8sConfig        *genericclioptions.ConfigFlags
+	formatterMu      sync.Mutex
+	env              string
+	remoteAddr       string
+	gadgetNamespace  string
 }
 
 // NewGadgetManager creates a new GadgetManager instance.
-func NewGadgetManager(env string, linuxRemoteAddress string, k8sConfig *genericclioptions.ConfigFlags) (GadgetManager, error) {
+func NewGadgetManager(env string, linuxRemoteAddress string, k8sConfig *genericclioptions.ConfigFlags, gadgetNamespace string) (GadgetManager, error) {
 	if env != "kubernetes" && env != "linux" {
 		return nil, fmt.Errorf("unsupported gadget manager environment: %s", env)
 	}
@@ -82,9 +83,10 @@ func NewGadgetManager(env string, linuxRemoteAddress string, k8sConfig *genericc
 		return nil, fmt.Errorf("linuxRemoteAddress must be set when environment is linux")
 	}
 	return &gadgetManager{
-		k8sConfig:  k8sConfig,
-		env:        env,
-		remoteAddr: linuxRemoteAddress,
+		k8sConfig:       k8sConfig,
+		env:             env,
+		remoteAddr:      linuxRemoteAddress,
+		gadgetNamespace: gadgetNamespace,
 	}, nil
 }
 
@@ -250,7 +252,13 @@ func (g *gadgetManager) getRuntime() (*grpcruntime.Runtime, error) {
 	if g.env == "kubernetes" {
 		environment.Environment = environment.Kubernetes
 		rt := grpcruntime.New(grpcruntime.WithConnectUsingK8SProxy)
-		if err := rt.Init(rt.GlobalParamDescs().ToParams()); err != nil {
+		gp := rt.GlobalParamDescs().ToParams()
+		if g.gadgetNamespace != "" {
+			if err := gp.Set(grpcruntime.ParamGadgetNamespace, g.gadgetNamespace); err != nil {
+				return nil, fmt.Errorf("setting gadget namespace: %w", err)
+			}
+		}
+		if err := rt.Init(gp); err != nil {
 			return nil, fmt.Errorf("initializing gadget runtime: %w", err)
 		}
 

--- a/pkg/gadgetmanager/gadgetmanager.go
+++ b/pkg/gadgetmanager/gadgetmanager.go
@@ -67,14 +67,15 @@ type GadgetInstance struct {
 }
 
 type gadgetManager struct {
-	k8sConfig   *genericclioptions.ConfigFlags
-	formatterMu sync.Mutex
-	env         string
-	remoteAddr  string
+	k8sConfig       *genericclioptions.ConfigFlags
+	formatterMu     sync.Mutex
+	env             string
+	remoteAddr      string
+	gadgetNamespace string
 }
 
 // NewGadgetManager creates a new GadgetManager instance.
-func NewGadgetManager(env string, linuxRemoteAddress string, k8sConfig *genericclioptions.ConfigFlags) (GadgetManager, error) {
+func NewGadgetManager(env string, linuxRemoteAddress string, k8sConfig *genericclioptions.ConfigFlags, gadgetNamespace string) (GadgetManager, error) {
 	if env != "kubernetes" && env != "linux" {
 		return nil, fmt.Errorf("unsupported gadget manager environment: %s", env)
 	}
@@ -82,9 +83,10 @@ func NewGadgetManager(env string, linuxRemoteAddress string, k8sConfig *genericc
 		return nil, fmt.Errorf("linuxRemoteAddress must be set when environment is linux")
 	}
 	return &gadgetManager{
-		k8sConfig:  k8sConfig,
-		env:        env,
-		remoteAddr: linuxRemoteAddress,
+		k8sConfig:       k8sConfig,
+		env:             env,
+		remoteAddr:      linuxRemoteAddress,
+		gadgetNamespace: gadgetNamespace,
 	}, nil
 }
 
@@ -250,7 +252,13 @@ func (g *gadgetManager) getRuntime() (*grpcruntime.Runtime, error) {
 	if g.env == "kubernetes" {
 		environment.Environment = environment.Kubernetes
 		rt := grpcruntime.New(grpcruntime.WithConnectUsingK8SProxy)
-		if err := rt.Init(rt.GlobalParamDescs().ToParams()); err != nil {
+		gp := rt.GlobalParamDescs().ToParams()
+		if g.gadgetNamespace != "" {
+			if err := gp.Set(grpcruntime.ParamGadgetNamespace, g.gadgetNamespace); err != nil {
+				return nil, fmt.Errorf("setting gadget namespace: %w", err)
+			}
+		}
+		if err := rt.Init(gp); err != nil {
 			return nil, fmt.Errorf("initializing gadget runtime: %w", err)
 		}
 


### PR DESCRIPTION
## Summary

- Adds a `-namespace` CLI flag to override the default `gadget` namespace used by the grpc runtime when looking for Inspektor Gadget pods
- When `-namespace` is not set, auto-discovers the namespace by querying for gadget DaemonSets in the cluster (using `FieldSelector=metadata.name=gadget` and `LabelSelector=k8s-app=gadget`)
- Falls back to the grpc runtime default (`gadget`) if no DaemonSets are found or discovery fails

## Motivation

In many Kubernetes environments, namespace naming follows organizational conventions and Inspektor Gadget may not be deployed in the default `gadget` namespace. Without this flag, the MCP server fails to find gadget pods and cannot expose gadget tools.

## Changes

- `cmd/ig-mcp-server/main.go`: Add `-namespace` flag, auto-discover namespace at startup, pass to `NewGadgetManager`
- `pkg/gadgetmanager/gadgetmanager.go`: Accept namespace parameter, set `ParamGadgetNamespace` on grpc runtime when non-empty
- `pkg/gadgetmanager/discover.go`: New file — `DiscoverGadgetNamespace` queries DaemonSets across all namespaces using the caller's k8sConfig